### PR TITLE
improve: this commits refactoring several parts in the kafka client and connector for better readability and error handling.

### DIFF
--- a/app/broker/connector/kafka_connector/kafka_connector.go
+++ b/app/broker/connector/kafka_connector/kafka_connector.go
@@ -61,12 +61,14 @@ func (c *Connector) NewConsumer(topic, group string, batchSize int, fn type2.Han
 		return err
 	}
 
+	consumer.Run(ctx)
+
 	c.consumers[topic+group+uuid.NewString()] = consumer
 
 	return nil
 }
 
-// Close close the connector
+// Close the connector
 func (c *Connector) Close() error {
 	for consumerName, consumer := range c.consumers {
 		if err := consumer.Close(); err != nil {

--- a/go.mod
+++ b/go.mod
@@ -20,7 +20,6 @@ require (
 	github.com/knadh/koanf/providers/file v0.1.0
 	github.com/knadh/koanf/v2 v2.0.1
 	github.com/mbobakov/grpc-consul-resolver v1.5.2
-	github.com/pkg/errors v0.9.1
 	github.com/prometheus/client_golang v1.16.0
 	github.com/redis/go-redis/extra/redisotel/v9 v9.0.5
 	github.com/redis/go-redis/v9 v9.0.5
@@ -185,6 +184,7 @@ require (
 	github.com/olekukonko/tablewriter v0.0.5 // indirect
 	github.com/pelletier/go-toml/v2 v2.0.9 // indirect
 	github.com/pierrec/lz4/v4 v4.1.18 // indirect
+	github.com/pkg/errors v0.9.1 // indirect
 	github.com/pmezard/go-difflib v1.0.1-0.20181226105442-5d4384ee4fb2 // indirect
 	github.com/polyfloyd/go-errorlint v1.4.3 // indirect
 	github.com/prometheus/client_model v0.4.0 // indirect

--- a/pkg/mq/kafka/client.go
+++ b/pkg/mq/kafka/client.go
@@ -89,7 +89,6 @@ func (c *client) SendMessage(ctx context.Context, msg *Message) (string, error) 
 	}
 
 	if err != nil {
-
 		return "", fmt.Errorf("failed to write topic=%s, address=%s messages %w", msg.Topic, c.Address, err)
 	}
 


### PR DESCRIPTION
- Removed direct import of "github.com/pkg/errors" in go package and added it back as an indirect import.
- Reworded and fixed some comments for better clarity.
- The error creation method in the kafka client is changed to the built-in method `fmt.Errorf` from `errors.Wrapf`.
- Moved the consumer startup line `consumer.Run(ctx)` to before the assignment of the consumer to the map in kafka connector file for a more logical sequence.
- Rearranged the timing of sleep and continue operations in for loop within `waitForTopic` function for better error handling.
- Moved `c.wg.Add(1)` from the Run method to the worker method in kafka client for better synchronization.