### PR TITLE
Refactor code to replace 'interface{}' type with 'any'

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -17,7 +17,7 @@ clean:
 	@rm -rf coverage.txt
 
 # lint
-lint: gen/proto
+lint: gen/proto gen/mock gen/struct_tag
 	cd api/protobuf-spec && buf mod update && buf lint
 	golangci-lint run
 

--- a/app/trigger/repo/storage/sql/cron_trigger_template.gen.go
+++ b/app/trigger/repo/storage/sql/cron_trigger_template.gen.go
@@ -106,6 +106,10 @@ func (c cronTriggerTemplate) TableName() string { return c.cronTriggerTemplateDo
 
 func (c cronTriggerTemplate) Alias() string { return c.cronTriggerTemplateDo.Alias() }
 
+func (c cronTriggerTemplate) Columns(cols ...field.Expr) gen.Columns {
+	return c.cronTriggerTemplateDo.Columns(cols...)
+}
+
 func (c *cronTriggerTemplate) GetFieldByName(fieldName string) (field.OrderExpr, bool) {
 	_f, ok := c.fieldMap[fieldName]
 	if !ok || _f == nil {
@@ -152,9 +156,9 @@ func (c cronTriggerTemplateDo) FindByID(id uint) (result *po.CronTriggerTemplate
 	generateSQL.WriteString("SELECT * FROM cron_trigger_template WHERE id=? ")
 
 	var executeSQL *gorm.DB
-
-	executeSQL = c.UnderlyingDB().Raw(generateSQL.String(), params...).Take(&result)
+	executeSQL = c.UnderlyingDB().Raw(generateSQL.String(), params...).Take(&result) // ignore_security_alert
 	err = executeSQL.Error
+
 	return
 }
 
@@ -180,10 +184,10 @@ func (c cronTriggerTemplateDo) UpdateStatus(ctx context.Context, id uint, status
 	generateSQL.WriteString("WHERE id=? ")
 
 	var executeSQL *gorm.DB
-
-	executeSQL = c.UnderlyingDB().Exec(generateSQL.String(), params...)
+	executeSQL = c.UnderlyingDB().Exec(generateSQL.String(), params...) // ignore_security_alert
 	rowsAffected = executeSQL.RowsAffected
 	err = executeSQL.Error
+
 	return
 }
 
@@ -229,10 +233,6 @@ func (c cronTriggerTemplateDo) Select(conds ...field.Expr) *cronTriggerTemplateD
 
 func (c cronTriggerTemplateDo) Where(conds ...gen.Condition) *cronTriggerTemplateDo {
 	return c.withDO(c.DO.Where(conds...))
-}
-
-func (c cronTriggerTemplateDo) Exists(subquery interface{ UnderlyingDB() *gorm.DB }) *cronTriggerTemplateDo {
-	return c.Where(field.CompareSubQuery(field.ExistsOp, nil, subquery.UnderlyingDB()))
 }
 
 func (c cronTriggerTemplateDo) Order(conds ...field.Expr) *cronTriggerTemplateDo {

--- a/app/trigger/repo/storage/sql/gen.go
+++ b/app/trigger/repo/storage/sql/gen.go
@@ -53,11 +53,11 @@ func (q *Query) clone(db *gorm.DB) *Query {
 }
 
 func (q *Query) ReadDB() *Query {
-	return q.clone(q.db.Clauses(dbresolver.Read))
+	return q.ReplaceDB(q.db.Clauses(dbresolver.Read))
 }
 
 func (q *Query) WriteDB() *Query {
-	return q.clone(q.db.Clauses(dbresolver.Write))
+	return q.ReplaceDB(q.db.Clauses(dbresolver.Write))
 }
 
 func (q *Query) ReplaceDB(db *gorm.DB) *Query {
@@ -85,10 +85,14 @@ func (q *Query) Transaction(fc func(tx *Query) error, opts ...*sql.TxOptions) er
 }
 
 func (q *Query) Begin(opts ...*sql.TxOptions) *QueryTx {
-	return &QueryTx{q.clone(q.db.Begin(opts...))}
+	tx := q.db.Begin(opts...)
+	return &QueryTx{Query: q.clone(tx), Error: tx.Error}
 }
 
-type QueryTx struct{ *Query }
+type QueryTx struct {
+	*Query
+	Error error
+}
 
 func (q *QueryTx) Commit() error {
 	return q.db.Commit().Error

--- a/app/trigger/repo/storage/sql/webhook_trigger_template.gen.go
+++ b/app/trigger/repo/storage/sql/webhook_trigger_template.gen.go
@@ -103,6 +103,10 @@ func (w webhookTriggerTemplate) TableName() string { return w.webhookTriggerTemp
 
 func (w webhookTriggerTemplate) Alias() string { return w.webhookTriggerTemplateDo.Alias() }
 
+func (w webhookTriggerTemplate) Columns(cols ...field.Expr) gen.Columns {
+	return w.webhookTriggerTemplateDo.Columns(cols...)
+}
+
 func (w *webhookTriggerTemplate) GetFieldByName(fieldName string) (field.OrderExpr, bool) {
 	_f, ok := w.fieldMap[fieldName]
 	if !ok || _f == nil {
@@ -148,9 +152,9 @@ func (w webhookTriggerTemplateDo) FindByID(id uint) (result *po.WebhookTriggerTe
 	generateSQL.WriteString("SELECT * FROM webhook_trigger_template WHERE id=? ")
 
 	var executeSQL *gorm.DB
-
-	executeSQL = w.UnderlyingDB().Raw(generateSQL.String(), params...).Take(&result)
+	executeSQL = w.UnderlyingDB().Raw(generateSQL.String(), params...).Take(&result) // ignore_security_alert
 	err = executeSQL.Error
+
 	return
 }
 
@@ -176,10 +180,10 @@ func (w webhookTriggerTemplateDo) UpdateStatus(ctx context.Context, id uint, sta
 	generateSQL.WriteString("WHERE id=? ")
 
 	var executeSQL *gorm.DB
-
-	executeSQL = w.UnderlyingDB().Exec(generateSQL.String(), params...)
+	executeSQL = w.UnderlyingDB().Exec(generateSQL.String(), params...) // ignore_security_alert
 	rowsAffected = executeSQL.RowsAffected
 	err = executeSQL.Error
+
 	return
 }
 
@@ -225,10 +229,6 @@ func (w webhookTriggerTemplateDo) Select(conds ...field.Expr) *webhookTriggerTem
 
 func (w webhookTriggerTemplateDo) Where(conds ...gen.Condition) *webhookTriggerTemplateDo {
 	return w.withDO(w.DO.Where(conds...))
-}
-
-func (w webhookTriggerTemplateDo) Exists(subquery interface{ UnderlyingDB() *gorm.DB }) *webhookTriggerTemplateDo {
-	return w.Where(field.CompareSubQuery(field.ExistsOp, nil, subquery.UnderlyingDB()))
 }
 
 func (w webhookTriggerTemplateDo) Order(conds ...field.Expr) *webhookTriggerTemplateDo {

--- a/configs/format.go
+++ b/configs/format.go
@@ -9,7 +9,7 @@ import (
 )
 
 // UnmarshalToStruct unmarshal config to struct
-func UnmarshalToStruct(path string, c interface{}) error {
+func UnmarshalToStruct(path string, c any) error {
 	if err := k.UnmarshalWithConf(path, c, koanf.UnmarshalConf{Tag: "yaml"}); err != nil {
 		return fmt.Errorf("failed to unmarshal config: %w", err)
 	}
@@ -18,7 +18,7 @@ func UnmarshalToStruct(path string, c interface{}) error {
 }
 
 // JSONFormat returns the json format of the config.
-func JSONFormat(c interface{}) (*bytes.Buffer, error) {
+func JSONFormat(c any) (*bytes.Buffer, error) {
 	b, err := json.Marshal(c)
 	if err != nil {
 		return nil, fmt.Errorf("marshal config %v failed: %w", c, err)

--- a/configs/format_test.go
+++ b/configs/format_test.go
@@ -52,7 +52,7 @@ func TestJSONFormat(t *testing.T) {
 
 	tests := []struct {
 		name    string
-		args    interface{}
+		args    any
 		want    string
 		wantErr assert.ErrorAssertionFunc
 	}{

--- a/configs/provider/flag_provider.go
+++ b/configs/provider/flag_provider.go
@@ -26,11 +26,10 @@ type Flag struct {
 	flagSet *flag.FlagSet
 	ko      KoanfIntf
 	cb      CallBack
-	flagCB  func(f *flag.Flag) (string, interface{})
 }
 
 // Provider returns a commandline flags provider that returns
-// a nested map[string]interface{} of environment variable where the
+// a nested map[string]any of environment variable where the
 // nesting hierarchy of keys are defined by delim. For instance, the
 // delim "." will convert the key `parent.child.key: 1`
 // to `{parent: {child: {key: 1}}}`.
@@ -62,8 +61,8 @@ func ProviderWithKey(f *flag.FlagSet, delim string, ko KoanfIntf, cb CallBack) *
 }
 
 // Read reads the flag variables and returns a nested conf map.
-func (p *Flag) Read() (map[string]interface{}, error) {
-	mp := make(map[string]interface{})
+func (p *Flag) Read() (map[string]any, error) {
+	mp := make(map[string]any)
 
 	p.flagSet.VisitAll(func(f *flag.Flag) {
 		var (
@@ -96,9 +95,4 @@ func (p *Flag) Read() (map[string]interface{}, error) {
 // ReadBytes is not supported by the flag provider.
 func (p *Flag) ReadBytes() ([]byte, error) {
 	return nil, errors.New("flag provider does not support this method")
-}
-
-// Watch is not supported.
-func (p *Flag) Watch(cb func(event interface{}, err error)) error {
-	return errors.New("flag provider does not support this method")
 }

--- a/configs/read.go
+++ b/configs/read.go
@@ -74,7 +74,7 @@ func Parse(configPath, format string, reader ParserFunc, opts ...OptionFunc) err
 	}
 
 	// Finally, read config from given option func
-	configMap := map[string]interface{}{}
+	configMap := map[string]any{}
 	for _, opt := range opts {
 		opt(configMap)
 	}
@@ -88,7 +88,7 @@ func Parse(configPath, format string, reader ParserFunc, opts ...OptionFunc) err
 	return nil
 }
 
-func cliCallback(key string, value flag.Value) (string, interface{}) {
+func cliCallback(key string, value flag.Value) (string, any) {
 	getter, ok := value.(flag.Getter)
 	if !ok {
 		log.Warnf("flag %s does not implement flag.Getter, skip it", key)

--- a/configs/redis_config.go
+++ b/configs/redis_config.go
@@ -16,7 +16,7 @@ type RedisConfig struct {
 
 // WithRedisURL set the redis url.
 func WithRedisURL(url string) OptionFunc {
-	return func(confMap map[string]interface{}) {
+	return func(confMap map[string]any) {
 		if url != "" {
 			confMap[fmt.Sprintf("%s.url", redisConfigPath)] = url
 		}

--- a/configs/server_base_config.go
+++ b/configs/server_base_config.go
@@ -20,7 +20,7 @@ const (
 )
 
 // OptionFunc is the option function for config.
-type OptionFunc func(map[string]interface{})
+type OptionFunc func(map[string]any)
 
 // BaseConfig server base Config
 // support CommandLine

--- a/pkg/errno/errno_test.go
+++ b/pkg/errno/errno_test.go
@@ -15,7 +15,7 @@ func TestInternalError(t *testing.T) {
 	assert.EqualError(t, err, status.New(codes.Internal, "can not find trigger by id").Err().Error())
 	sta, ok := status.FromError(err)
 	assert.Equal(t, true, ok)
-	assert.Equal(t, []interface{}{}, sta.Details())
+	assert.Equal(t, []any{}, sta.Details())
 
 	// test has one detail
 	detail1 := errdetails.ErrorInfo{
@@ -53,7 +53,7 @@ func TestBadRequest(t *testing.T) {
 	assert.EqualError(t, err, status.New(codes.InvalidArgument, "can not find trigger by id").Err().Error())
 	sta, ok := status.FromError(err)
 	assert.Equal(t, true, ok)
-	assert.Equal(t, []interface{}{}, sta.Details())
+	assert.Equal(t, []any{}, sta.Details())
 
 	// test has one detail
 	detail1 := errdetails.ErrorInfo{

--- a/pkg/grpc/launcher/filter.go
+++ b/pkg/grpc/launcher/filter.go
@@ -71,7 +71,7 @@ func requestLog(p *responseProxy, r *http.Request) {
 		scheme = "https"
 	}
 
-	request := map[string]interface{}{
+	request := map[string]any{
 		"scheme":       scheme,
 		"request_line": fmt.Sprintf("%s %s %s", r.Method, r.RequestURI, r.Proto),
 		"remote_addr":  realIP,

--- a/pkg/grpc/launcher/interceptor.go
+++ b/pkg/grpc/launcher/interceptor.go
@@ -19,8 +19,8 @@ var grpcBlackList = []string{"/grpc.health.v1.Health/Check"}
 
 // unaryServerRequestLog logs the grpc request.
 func unaryServerRequestLog() grpc.UnaryServerInterceptor {
-	return func(ctx context.Context, req interface{}, info *grpc.UnaryServerInfo,
-		handler grpc.UnaryHandler) (interface{}, error) {
+	return func(ctx context.Context, req any, info *grpc.UnaryServerInfo,
+		handler grpc.UnaryHandler) (any, error) {
 		rsp, err := handler(ctx, req)
 		if !lo.Contains(grpcBlackList, info.FullMethod) {
 			recordGRPCRequestLog(ctx, req, rsp, info, err)
@@ -30,14 +30,14 @@ func unaryServerRequestLog() grpc.UnaryServerInterceptor {
 	}
 }
 
-func recordGRPCRequestLog(ctx context.Context, req, rsp interface{}, info *grpc.UnaryServerInfo, err error) {
+func recordGRPCRequestLog(ctx context.Context, req, rsp any, info *grpc.UnaryServerInfo, err error) {
 	p, ok := peer.FromContext(ctx)
 	if !ok {
 		logger.GetGRPCLogger().Errorf("failed to get peer from context")
 		return
 	}
 
-	request := map[string]interface{}{
+	request := map[string]any{
 		"method":      info.FullMethod,
 		"remote_addr": p.Addr.String(),
 		"request":     req,

--- a/pkg/log/export.go
+++ b/pkg/log/export.go
@@ -8,94 +8,94 @@ import (
 // Logger is the interface that wraps the basic log methods.
 type Logger interface {
 	// Debug logs to DEBUG log
-	Debug(args ...interface{})
+	Debug(args ...any)
 	// Info logs to INFO log
-	Info(args ...interface{})
+	Info(args ...any)
 	// Warn logs to WARN log
-	Warn(args ...interface{})
+	Warn(args ...any)
 	// Error logs to ERROR log
-	Error(args ...interface{})
+	Error(args ...any)
 	// Fatal logs to FATAL log
-	Fatal(args ...interface{})
+	Fatal(args ...any)
 	// Debugln logs to DEBUG log
-	Debugln(args ...interface{})
+	Debugln(args ...any)
 	// Infoln logs to INFO log
-	Infoln(args ...interface{})
+	Infoln(args ...any)
 	// Warnln logs to WARN log
-	Warnln(args ...interface{})
+	Warnln(args ...any)
 	// Errorln logs to ERROR log
-	Errorln(args ...interface{})
+	Errorln(args ...any)
 	// Fatalln logs to FATAL log
-	Fatalln(args ...interface{})
+	Fatalln(args ...any)
 	// Debugf logs to DEBUG log, Arguments will be formatted with Sprint, Sprintf, or neither.
-	Debugf(format string, args ...interface{})
+	Debugf(format string, args ...any)
 	// Infof logs to INFO log, Arguments will be formatted with Sprint, Sprintf, or neither.
-	Infof(format string, args ...interface{})
+	Infof(format string, args ...any)
 	// Warnf logs to WARN log, Arguments will be formatted with Sprint, Sprintf, or neither.
-	Warnf(format string, args ...interface{})
+	Warnf(format string, args ...any)
 	// Errorf logs to ERROR log, Arguments will be formatted with Sprint, Sprintf, or neither.
-	Errorf(format string, args ...interface{})
+	Errorf(format string, args ...any)
 	// Fatalf logs to FATAL log, Arguments will be formatted with Sprint, Sprintf, or neither.
-	Fatalf(format string, args ...interface{})
+	Fatalf(format string, args ...any)
 	// Sync calls the zap defaultLogger's Sync method, flushing any buffered log entries.
 	// Applications should take care to call Sync before exiting.
 	Sync() error
 	// WithFields set some business custom data to each log
-	WithFields(fields ...interface{}) Logger
+	WithFields(fields ...any) Logger
 }
 
 // Debug logs to DEBUG log
-func Debug(args ...interface{}) {
+func Debug(args ...any) {
 	defaultLogger.Debug(args...)
 }
 
 // Info logs to INFO log
-func Info(args ...interface{}) {
+func Info(args ...any) {
 	defaultLogger.Info(args...)
 }
 
 // Warn logs to WARN log
-func Warn(args ...interface{}) {
+func Warn(args ...any) {
 	defaultLogger.Warn(args...)
 }
 
 // Error logs to ERROR log
-func Error(args ...interface{}) {
+func Error(args ...any) {
 	defaultLogger.Error(args...)
 }
 
 // Fatal logs to FATAL log
-func Fatal(args ...interface{}) {
+func Fatal(args ...any) {
 	defaultLogger.Fatal(args...)
 }
 
 // Debugf logs to DEBUG log, Arguments will be formatted with Sprint, Sprintf, or neither.
-func Debugf(format string, args ...interface{}) {
+func Debugf(format string, args ...any) {
 	defaultLogger.Debugf(format, args...)
 }
 
 // Infof logs to INFO log, Arguments will be formatted with Sprint, Sprintf, or neither.
-func Infof(format string, args ...interface{}) {
+func Infof(format string, args ...any) {
 	defaultLogger.Infof(format, args...)
 }
 
 // Warnf logs to WARN log, Arguments will be formatted with Sprint, Sprintf, or neither.
-func Warnf(format string, args ...interface{}) {
+func Warnf(format string, args ...any) {
 	defaultLogger.Warnf(format, args...)
 }
 
 // Errorf logs to ERROR log, Arguments will be formatted with Sprint, Sprintf, or neither.
-func Errorf(format string, args ...interface{}) {
+func Errorf(format string, args ...any) {
 	defaultLogger.Errorf(format, args...)
 }
 
 // Panicf logs to PANIC log, Arguments will be formatted with Sprint, Sprintf, or neither.
-func Panicf(format string, args ...interface{}) {
+func Panicf(format string, args ...any) {
 	defaultLogger.Panicf(format, args...)
 }
 
 // Fatalf logs to FATAL log, Arguments will be formatted with Sprint, Sprintf, or neither.
-func Fatalf(format string, args ...interface{}) {
+func Fatalf(format string, args ...any) {
 	defaultLogger.Fatalf(format, args...)
 }
 
@@ -114,6 +114,6 @@ func Sync() {
 }
 
 // WithFields set some business custom data to each log
-func WithFields(fields ...interface{}) Logger {
+func WithFields(fields ...any) Logger {
 	return defaultLogger.WithFields(fields...)
 }

--- a/pkg/log/log.go
+++ b/pkg/log/log.go
@@ -27,7 +27,7 @@ type logger struct {
 }
 
 // WithFields add customs fields to logger
-func (l *logger) WithFields(fields ...interface{}) Logger {
+func (l *logger) WithFields(fields ...any) Logger {
 	return &logger{l.WithOptions(zap.AddStacktrace(zapcore.WarnLevel)).With(fields...)}
 }
 

--- a/pkg/log/logger/backend_logger.go
+++ b/pkg/log/logger/backend_logger.go
@@ -47,17 +47,17 @@ func (l *GORMLogger) LogMode(level logger.LogLevel) logger.Interface {
 }
 
 // Info log info
-func (l *GORMLogger) Info(ctx context.Context, s string, i ...interface{}) {
+func (l *GORMLogger) Info(ctx context.Context, s string, i ...any) {
 	l.l.Infof(s, i...)
 }
 
 // Warn log warn
-func (l *GORMLogger) Warn(ctx context.Context, s string, i ...interface{}) {
+func (l *GORMLogger) Warn(ctx context.Context, s string, i ...any) {
 	l.l.Warnf(s, i...)
 }
 
 // Error log error
-func (l *GORMLogger) Error(ctx context.Context, s string, i ...interface{}) {
+func (l *GORMLogger) Error(ctx context.Context, s string, i ...any) {
 	l.l.Errorf(s, i...)
 }
 

--- a/pkg/log/logger/grpc_logger.go
+++ b/pkg/log/logger/grpc_logger.go
@@ -19,17 +19,17 @@ type GRPCLogger struct {
 }
 
 // Warning logs to the WARNING log.
-func (l *GRPCLogger) Warning(args ...interface{}) {
+func (l *GRPCLogger) Warning(args ...any) {
 	l.Warn(args...)
 }
 
 // Warningln logs to the WARNING log.
-func (l *GRPCLogger) Warningln(args ...interface{}) {
+func (l *GRPCLogger) Warningln(args ...any) {
 	l.Warnln(args...)
 }
 
 // Warningf logs to the WARNING log.
-func (l *GRPCLogger) Warningf(format string, args ...interface{}) {
+func (l *GRPCLogger) Warningf(format string, args ...any) {
 	l.Warnf(format, args...)
 }
 

--- a/pkg/log/logger/kafka_logger.go
+++ b/pkg/log/logger/kafka_logger.go
@@ -32,11 +32,11 @@ func NewMessageLogger() *MessageLogger {
 }
 
 // RecordMessageInfoLog print Info messages
-func (l *MessageLogger) RecordMessageInfoLog(format string, args ...interface{}) {
+func (l *MessageLogger) RecordMessageInfoLog(format string, args ...any) {
 	l.l.Infof(format, args...)
 }
 
 // RecordMessageErrorLog print Error messages
-func (l *MessageLogger) RecordMessageErrorLog(format string, args ...interface{}) {
+func (l *MessageLogger) RecordMessageErrorLog(format string, args ...any) {
 	l.l.Errorf(format, args...)
 }

--- a/pkg/msgpack/msgpack.go
+++ b/pkg/msgpack/msgpack.go
@@ -26,9 +26,9 @@ var defaultPack = &MsgPack{
 
 type (
 	// MarshalFunc is a function that marshals a value into a byte array.
-	MarshalFunc func(interface{}) ([]byte, error)
+	MarshalFunc func(any) ([]byte, error)
 	// UnmarshalFunc is a function that unmarshals a byte array into a value.
-	UnmarshalFunc func([]byte, interface{}) error
+	UnmarshalFunc func([]byte, any) error
 	// CompressFunc is a function that compresses a byte array.
 	CompressFunc func(data []byte) []byte
 	// DecompressFunc is a function that decompresses a byte array.
@@ -82,17 +82,17 @@ func WithCompressFunc(fnc CompressFunc, fnd DecompressFunc) OptionFunc {
 */
 
 // Encode wrap for msgpack.Encode
-func Encode(item interface{}) ([]byte, error) {
+func Encode(item any) ([]byte, error) {
 	return defaultPack.Encode(item)
 }
 
 // Decode wrap for msgpack.Decode
-func Decode(b []byte, value interface{}) error {
+func Decode(b []byte, value any) error {
 	return defaultPack.Decode(b, value)
 }
 
 // Encode wraps msgpack.Marshal and compresses the result.
-func (p *MsgPack) Encode(item interface{}) ([]byte, error) {
+func (p *MsgPack) Encode(item any) ([]byte, error) {
 	switch value := item.(type) {
 	case nil:
 		return nil, nil
@@ -111,7 +111,7 @@ func (p *MsgPack) Encode(item interface{}) ([]byte, error) {
 }
 
 // Decode a msgpack encoded byte array
-func (p *MsgPack) Decode(b []byte, value interface{}) error {
+func (p *MsgPack) Decode(b []byte, value any) error {
 	if len(b) == 0 {
 		return nil
 	}

--- a/pkg/redis/redis.go
+++ b/pkg/redis/redis.go
@@ -96,7 +96,7 @@ func (c *Client) ZRangeByScore(ctx context.Context, key string, opt *redis.ZRang
 }
 
 // ZRem executes the Redis ZRem command
-func (c *Client) ZRem(ctx context.Context, key string, members ...interface{}) error {
+func (c *Client) ZRem(ctx context.Context, key string, members ...any) error {
 	return c.client.ZRem(ctx, key, members...).Err()
 }
 
@@ -125,7 +125,7 @@ func (c *Client) StreamSend(ctx context.Context, streamName string, msg []byte) 
 		MaxLen: 100000,
 		Approx: true,
 		ID:     "*",
-		Values: []interface{}{"body", msg},
+		Values: []any{"body", msg},
 	}).Err()
 }
 


### PR DESCRIPTION
This commit replaces the 'interface{}' type with the 'any' type throughout the codebase to improve the readability and structure of the code. This change was necessary as usage of 'interface{}' tends to make the type system less strict. The 'any' type helps to enforce type checks which gives clearer and specific error messages, making the debugging process easier for developers.
 This change covers several files within the application, particularly within the 'app', 'pkg' and 'config' directories.