### PR TITLE
feat: implement distributed queue

### DIFF
--- a/api/protobuf-spec/buf.lock
+++ b/api/protobuf-spec/buf.lock
@@ -4,10 +4,10 @@ deps:
   - remote: buf.build
     owner: googleapis
     repository: googleapis
-    commit: 711e289f6a384c4caeebaff7c6931ade
-    digest: shake256:e08fb55dad7469f69df00304eed31427d2d1576e9aab31e6bf86642688e04caaf0372f15fe6974cf79432779a635b3ea401ca69c943976dc42749524e4c25d94
+    commit: 28151c0d0a1641bf938a7672c500e01d
+    digest: shake256:49215edf8ef57f7863004539deff8834cfb2195113f0b890dd1f67815d9353e28e668019165b9d872395871eeafcbab3ccfdb2b5f11734d3cca95be9e8d139de
   - remote: buf.build
     owner: grpc-ecosystem
     repository: grpc-gateway
-    commit: fed2dcdcfd694403ad51cd3c94957830
-    digest: shake256:ed076a21e3d772892fc465ced0e4dd50f9dba86fdd4473920eaa25efa4807644e8e021be423dcfcee74bf4242e7e57422393f9b1abb10acb18ea1a5df509bb19
+    commit: f460f71081c14a80b66cc72526e0b322
+    digest: shake256:122def85e91fc3ef4ab351680060b8f70e9d09a7ae6d1412aeb2bddfeee5c4d3fc8819da33fef56192cec0a817ac0c3e6d49bb2acf02eb5c9e9131739a60ddfc

--- a/pkg/cluster/cluster.go
+++ b/pkg/cluster/cluster.go
@@ -9,8 +9,6 @@ import (
 
 	clientv3 "go.etcd.io/etcd/client/v3"
 	"go.etcd.io/etcd/client/v3/concurrency"
-
-	"github.com/beihai0xff/pudding/pkg/log"
 )
 
 type (
@@ -18,6 +16,8 @@ type (
 	Cluster interface {
 		// Mutex returns a distributed mutex implementation.
 		Mutex(name string, ttl time.Duration, opts ...MutexOption) (Mutex, error)
+		// Queue returns a distributed queue implementation.
+		Queue(topic string) (Queue, error)
 	}
 
 	// cluster is a cluster manager implementation.
@@ -74,8 +74,6 @@ func (c *cluster) getSession(ctx context.Context, ttl int64) (*concurrency.Sessi
 	if err != nil {
 		return nil, fmt.Errorf("create session failed: %v", err)
 	}
-
-	log.Infof("session is ready")
 
 	return session, nil
 }

--- a/pkg/cluster/cluster_test.go
+++ b/pkg/cluster/cluster_test.go
@@ -1,6 +1,7 @@
 package cluster
 
 import (
+	"context"
 	"testing"
 	"time"
 
@@ -20,6 +21,7 @@ func TestMain(m *testing.M) {
 	testCluster = newCluster(client, WithRequestTimeout(time.Second))
 
 	m.Run()
+	testCluster.client.Delete(context.Background(), "/test", clientv3.WithPrefix())
 }
 
 func Test_newCluster(t *testing.T) {

--- a/pkg/cluster/mutex.go
+++ b/pkg/cluster/mutex.go
@@ -35,6 +35,9 @@ type Mutex interface {
 	// May return ErrLockNotHeld.
 	Unlock(ctx context.Context) error
 
+	// IsHeld returns whether the lock is held.
+	IsHeld() (bool, error)
+
 	// Refresh extends the lock with TTL.
 	// recommended use it when keepAlive is false
 	// will return ErrLockNotHeld if refresh is unsuccessful.
@@ -84,6 +87,19 @@ func (m *mutex) Lock(ctx context.Context) (err error) {
 	isTimeout = false
 
 	return
+}
+
+// IsHeld returns whether the lock is held.
+func (m *mutex) IsHeld() (bool, error) {
+	if err := m.m.TryLock(context.Background()); err != nil {
+		if errors.Is(err, concurrency.ErrLocked) {
+			return false, nil
+		}
+
+		return false, err
+	}
+
+	return true, nil
 }
 
 func (m *mutex) Unlock(ctx context.Context) error {

--- a/pkg/cluster/mutex_test.go
+++ b/pkg/cluster/mutex_test.go
@@ -55,3 +55,21 @@ func refreshMutexAfter(t *testing.T, m Mutex, d time.Duration) {
 		t.Logf("refresh lock ttl: %v", resp.TTL)
 	}
 }
+
+func Test_mutex_TryLock(t *testing.T) {
+	mutex, err := testCluster.Mutex("test", 2*time.Second, WithDisableKeepalive())
+	assert.NoError(t, err)
+	mutex2, err := testCluster.Mutex("test", 2*time.Second, WithDisableKeepalive())
+	assert.NoError(t, err)
+
+	ctx := context.Background()
+	assert.NoError(t, mutex.Lock(ctx))
+	held, err := mutex.TryLock()
+	assert.Equal(t, true, held)
+	held2, err := mutex2.TryLock()
+	assert.Equal(t, false, held2)
+
+	assert.NoError(t, mutex.Unlock(ctx))
+	held, err = mutex.TryLock()
+	assert.Equal(t, true, held)
+}

--- a/pkg/cluster/queue.go
+++ b/pkg/cluster/queue.go
@@ -36,10 +36,9 @@ type Message struct {
 }
 
 // queue implements a single-reader, multi-writer distributed queue.
-// /namespace/topic/msg/key
-// /namespace/topic/acked/key_rev
-// /namespace/topic/unacked/key_rev
-// /namespace/topic/consumerID
+// /namespace/topic/msg/key (value: value)
+// /namespace/topic/unacked (value: consumer_id, rev)
+// /namespace/topic/consumer (mutex)
 type queue struct {
 	client        *v3.Client
 	topic         string

--- a/pkg/cluster/queue.go
+++ b/pkg/cluster/queue.go
@@ -92,7 +92,7 @@ func (q *queue) Consume(ctx context.Context) (*Message, error) {
 	for {
 		log.Debugf("try to get message from the topic [%s]", q.topic)
 
-		if held, err := q.consumerMutex.IsHeld(); err != nil {
+		if held, err := q.consumerMutex.TryLock(); err != nil {
 			return nil, err
 		} else if !held {
 			// wait for the lock, only one consumer can consume the message

--- a/pkg/cluster/queue.go
+++ b/pkg/cluster/queue.go
@@ -1,0 +1,223 @@
+package cluster
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"strings"
+	"time"
+
+	"github.com/google/uuid"
+	"go.etcd.io/etcd/api/v3/mvccpb"
+	v3 "go.etcd.io/etcd/client/v3"
+	"go.etcd.io/etcd/client/v3/concurrency"
+
+	"github.com/beihai0xff/pudding/pkg/log"
+)
+
+// Queue is a distributed queue implementation based on etcd
+type Queue interface {
+	// Produce adds an element to the queue.
+	Produce(m *Message) (string, error)
+	// Consume returns the first element in the queue.
+	Consume(ctx context.Context) (*Message, error)
+	// Commit removes the element from the queue.
+	Commit(msg *Message) error
+}
+
+// Message is the unit of the queue
+type Message struct {
+	// Key is the unique identifier of the message
+	Key string
+	// Value is the content of the message
+	Value string
+	// the key is unique in the queue
+	Unique bool
+}
+
+// queue implements a single-reader, multi-writer distributed queue.
+// /namespace/topic/msg/key
+// /namespace/topic/acked/key_rev
+// /namespace/topic/unacked/key_rev
+// /namespace/topic/consumerID
+type queue struct {
+	client        *v3.Client
+	topic         string
+	consumerMutex Mutex
+	consumerID    string
+}
+
+// Queue creates a new queue.
+func (c *cluster) Queue(topic string) (Queue, error) {
+	return newQueue(c, topic)
+}
+
+func newQueue(cluster *cluster, topic string) (*queue, error) {
+	q := queue{
+		client:     cluster.client,
+		topic:      topic,
+		consumerID: uuid.New().String(),
+	}
+
+	m, err := cluster.Mutex(q.getConsumerLockPath(), 5*time.Second)
+	if err != nil {
+		return nil, err
+	}
+
+	q.consumerMutex = m
+
+	return &q, nil
+}
+
+func (q *queue) Produce(m *Message) (string, error) {
+	messageID := m.Key
+	if !m.Unique {
+		// the message do not need unique, add an uuid to make it won't conflict with other messages
+		messageID = fmt.Sprintf("%s/%s", messageID, uuid.New().String())
+	}
+
+	// if the messageID is non-unique, an error will be returned
+	if err := putNewKV(q.client.KV, q.getMsgPath()+messageID, m.Value, v3.NoLease); err != nil {
+		return "", err
+	}
+
+	return messageID, nil
+}
+
+// Consume returns Produce()'d elements in FIFO order. If the
+// queue is empty, Consume blocks until elements are available.
+//
+//nolint:gocyclo
+func (q *queue) Consume(ctx context.Context) (*Message, error) {
+	for {
+		if held, err := q.consumerMutex.IsHeld(); err != nil {
+			return nil, err
+		} else if !held {
+			// wait for the lock, only one consumer can consume the message
+			if err := q.consumerMutex.Lock(ctx); err != nil {
+				return nil, err
+			}
+		}
+
+		resp, err := q.client.KV.Get(ctx, q.getMsgPath(), v3.WithFirstRev()...)
+		if err != nil {
+			return nil, err
+		}
+
+		if len(resp.Kvs) != 0 {
+			kv := resp.Kvs[0]
+
+			rev, err := q.tryUnackMessage(kv)
+			if err != nil {
+				return nil, err
+			}
+
+			if rev != 0 {
+				_, err := waitKeyEvents(q.client, q.getUnAckedPath(), rev, []mvccpb.Event_EventType{mvccpb.DELETE})
+				if err != nil {
+					return nil, err
+				}
+
+				continue
+			}
+
+			return q.message(kv), nil
+		}
+
+		log.Infof("no message in the topic [%s] , wait for new message", q.topic)
+
+		ev, err := waitPrefixEvents(
+			q.client,
+			q.getMsgPath(),
+			resp.Header.Revision,
+			[]mvccpb.Event_EventType{mvccpb.PUT})
+		if err != nil {
+			return nil, err
+		}
+
+		// If watch type is PUT, it indicates new data has been stored to the key.
+		return q.message(ev.Kv), nil
+	}
+}
+
+func (q *queue) Commit(msg *Message) error {
+	key := fmt.Sprintf("%s%s", q.getMsgPath(), msg.Key)
+	_, err := concurrency.NewSTM(q.client, func(stm concurrency.STM) error {
+		rev := stm.Rev(key)
+		// the message has been consumed
+		if rev == 0 {
+			return nil
+		}
+		stm.Del(q.getUnAckedPath())
+		stm.Del(key)
+		return nil
+	})
+
+	return err
+}
+
+// tryUnackMessage try to lock the message
+// if the message has been locked, return false
+func (q *queue) tryUnackMessage(kv *mvccpb.KeyValue) (int64, error) {
+	var rev int64
+
+	_, err := concurrency.NewSTM(q.client, func(stm concurrency.STM) error {
+		rev = stm.Rev(q.getUnAckedPath())
+		if rev != 0 {
+			v := unAckedValue{}
+			v.parse(stm.Get(q.getUnAckedPath()))
+			// the message has been locked by the consumer
+			// need to wait for the consumer to commit the message
+			if v.ConsumerID == q.consumerID {
+				// return the rev of the message
+				return nil
+			}
+			// the message has been locked by other consumer
+			// but the consumer has not commit the message and the consumer is dead
+			// so we can lock the message and reconsume it
+			rev = 0
+		}
+
+		v := unAckedValue{
+			ConsumerID: q.consumerID,
+			Rev:        kv.CreateRevision,
+		}
+		stm.Put(q.getUnAckedPath(), v.jsonFormat())
+		return nil
+	})
+
+	return rev, err
+}
+
+func (q *queue) message(kv *mvccpb.KeyValue) *Message {
+	return &Message{
+		Key:   strings.TrimPrefix(string(kv.Key), q.getMsgPath()),
+		Value: string(kv.Value),
+	}
+}
+
+func (q *queue) getMsgPath() string {
+	return fmt.Sprintf("%s/msg/", q.topic)
+}
+
+func (q *queue) getUnAckedPath() string {
+	return fmt.Sprintf("%s/unacked", q.topic)
+}
+
+func (q *queue) getConsumerLockPath() string {
+	return fmt.Sprintf("%s/consumer", q.topic)
+}
+
+type unAckedValue struct {
+	ConsumerID string `json:"consumer_id"`
+	Rev        int64  `json:"rev"`
+}
+
+func (v *unAckedValue) jsonFormat() string {
+	b, _ := json.Marshal(v)
+	return string(b)
+}
+
+func (v *unAckedValue) parse(s string) {
+	_ = json.Unmarshal([]byte(s), v)
+}

--- a/pkg/cluster/queue_test.go
+++ b/pkg/cluster/queue_test.go
@@ -1,0 +1,138 @@
+package cluster
+
+import (
+	"context"
+	"fmt"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	v3 "go.etcd.io/etcd/client/v3"
+)
+
+func Test_queue_Produce_Unique_key(t *testing.T) {
+	q, _ := newQueue(testCluster, "/test/Produce")
+
+	uMsg := &Message{
+		Key:    "1123",
+		Value:  "value",
+		Unique: true,
+	}
+
+	defer q.client.Delete(context.Background(), "/test/Produce", v3.WithPrefix())
+
+	got, err := q.Produce(uMsg)
+	assert.NoError(t, err)
+	assert.Equal(t, got, uMsg.Key, "the messageID should Equal the key")
+	got, err = q.Produce(uMsg)
+	assert.ErrorIs(t, ErrKeyExists, err)
+	assert.Equal(t, "", got)
+}
+
+func Test_queue_Produce_non_unique_key(t *testing.T) {
+	q, _ := newQueue(testCluster, "/test/Produce")
+	defer q.client.Delete(context.Background(), "/test/Produce", v3.WithPrefix())
+
+	uMsg := &Message{
+		Key:    "1123",
+		Value:  "value",
+		Unique: false,
+	}
+
+	for i := 0; i < 3; i++ {
+		got, err := q.Produce(uMsg)
+		assert.NoError(t, err)
+		assert.Contains(t, got, uMsg.Key, "the messageID should Contains the key")
+		fmt.Println(got)
+	}
+}
+
+func Test_queue_Consume(t *testing.T) {
+	q, _ := newQueue(testCluster, "/test/Produce")
+	defer q.client.Delete(context.Background(), "/test/Produce", v3.WithPrefix())
+
+	go func() {
+		for i := 0; i < 4; i++ {
+			uMsg := &Message{
+				Key:    fmt.Sprintf("%d", i),
+				Value:  "value",
+				Unique: true,
+			}
+			got, err := q.Produce(uMsg)
+			assert.NoError(t, err)
+			assert.Equal(t, got, uMsg.Key)
+			time.Sleep(time.Second)
+		}
+
+	}()
+
+	for i := 0; i < 4; i++ {
+		got, err := q.Consume(context.Background())
+		assert.NoError(t, err)
+		assert.Equal(t, fmt.Sprintf("%d", i), got.Key)
+		assert.NoError(t, q.Commit(got))
+	}
+}
+
+func Test_queue_Consume_wait_key(t *testing.T) {
+	q, _ := newQueue(testCluster, "/test/Produce")
+	defer q.client.Delete(context.Background(), "/test/Produce", v3.WithPrefix())
+
+	for i := 0; i < 4; i++ {
+		uMsg := &Message{
+			Key:    fmt.Sprintf("%d", i),
+			Value:  "value",
+			Unique: true,
+		}
+		messageID, err := q.Produce(uMsg)
+		assert.NoError(t, err)
+		assert.Equal(t, messageID, uMsg.Key)
+	}
+
+	got, err := q.Consume(context.Background())
+	assert.NoError(t, err)
+	assert.Equal(t, "0", got.Key)
+	go func() {
+		start := time.Now()
+		got, err := q.Consume(context.Background())
+		assert.Equal(t, true, time.Since(start) > time.Second)
+		assert.NoError(t, err)
+		assert.Equal(t, "1", got.Key)
+		assert.NoError(t, q.Commit(got))
+	}()
+	time.Sleep(2 * time.Second)
+	assert.NoError(t, q.Commit(got))
+
+	got, err = q.Consume(context.Background())
+	assert.NoError(t, err)
+	assert.Equal(t, "2", got.Key)
+	assert.NoError(t, q.Commit(got))
+}
+
+func Test_queue_Commit(t *testing.T) {
+	q, _ := newQueue(testCluster, "/test/Produce")
+	defer q.client.Delete(context.Background(), "/test/Produce", v3.WithPrefix())
+
+	uMsg := &Message{
+		Key:    "key",
+		Value:  "value",
+		Unique: true,
+	}
+	messageID, err := q.Produce(uMsg)
+	assert.NoError(t, err)
+	assert.Equal(t, messageID, uMsg.Key)
+
+	got, err := q.Consume(context.Background())
+	assert.NoError(t, err)
+	assert.Equal(t, uMsg.Key, got.Key)
+	assert.NoError(t, q.Commit(got))
+	assert.NoError(t, q.Commit(got))
+
+	messageID, err = q.Produce(uMsg)
+	assert.NoError(t, err)
+	assert.Equal(t, messageID, uMsg.Key)
+	got, err = q.Consume(context.Background())
+	assert.NoError(t, err)
+	assert.Equal(t, uMsg.Key, got.Key)
+	assert.NoError(t, q.Commit(got))
+}

--- a/pkg/cluster/queue_test.go
+++ b/pkg/cluster/queue_test.go
@@ -78,7 +78,7 @@ func Test_queue_Consume_wait_key(t *testing.T) {
 	q, _ := newQueue(testCluster, "/test/Produce")
 	defer q.client.Delete(context.Background(), "/test/Produce", v3.WithPrefix())
 
-	for i := 0; i < 4; i++ {
+	for i := 0; i < 3; i++ {
 		uMsg := &Message{
 			Key:    fmt.Sprintf("%d", i),
 			Value:  "value",
@@ -99,10 +99,11 @@ func Test_queue_Consume_wait_key(t *testing.T) {
 		assert.NoError(t, err)
 		assert.Equal(t, "1", got.Key)
 		assert.NoError(t, q.Commit(got))
+		time.Sleep(time.Second)
 	}()
-	time.Sleep(2 * time.Second)
+	time.Sleep(time.Second)
 	assert.NoError(t, q.Commit(got))
-
+	time.Sleep(time.Second)
 	got, err = q.Consume(context.Background())
 	assert.NoError(t, err)
 	assert.Equal(t, "2", got.Key)

--- a/pkg/cluster/utils.go
+++ b/pkg/cluster/utils.go
@@ -1,0 +1,93 @@
+package cluster
+
+import (
+	"context"
+	"errors"
+
+	"go.etcd.io/etcd/api/v3/mvccpb"
+	v3 "go.etcd.io/etcd/client/v3"
+)
+
+var (
+	// ErrKeyExists is returned by putNewKV when the key already exists.
+	ErrKeyExists = errors.New("key already exists")
+	// ErrNoWatcher is returned when the watcher channel is nil.
+	ErrNoWatcher = errors.New("no watcher channel")
+)
+
+// putNewKV attempts to create the given key, only succeeding if the key did
+// not yet exist.
+func putNewKV(kv v3.KV, key, val string, leaseID v3.LeaseID) error {
+	cmp := v3.Compare(v3.Version(key), "=", 0)
+	req := v3.OpPut(key, val, v3.WithLease(leaseID))
+
+	txnResp, err := kv.Txn(context.TODO()).If(cmp).Then(req).Commit()
+	if err != nil {
+		return err
+	}
+
+	if !txnResp.Succeeded {
+		return ErrKeyExists
+	}
+
+	return nil
+}
+
+// deleteRevKey deletes a key by revision, returning false if key is missing
+func deleteRevKey(kv v3.KV, key string, rev int64) (bool, error) {
+	cmp := v3.Compare(v3.ModRevision(key), "=", rev)
+	req := v3.OpDelete(key)
+
+	txnResp, err := kv.Txn(context.TODO()).If(cmp).Then(req).Commit()
+	if err != nil {
+		return false, err
+	} else if !txnResp.Succeeded {
+		return false, nil
+	}
+
+	return true, nil
+}
+
+// waitPrefixEvents waits for the given events on the prefix.
+func waitPrefixEvents(c *v3.Client, prefix string, rev int64, evs []mvccpb.Event_EventType) (*v3.Event, error) {
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	wc := c.Watch(ctx, prefix, v3.WithPrefix(), v3.WithRev(rev))
+	if wc == nil {
+		return nil, ErrNoWatcher
+	}
+
+	return waitEvents(wc, evs), nil
+}
+
+// waitKeyEvents waits for the given events on the key.
+func waitKeyEvents(c *v3.Client, key string, rev int64, evs []mvccpb.Event_EventType) (*v3.Event, error) {
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	wc := c.Watch(ctx, key, v3.WithRev(rev))
+
+	if wc == nil {
+		return nil, ErrNoWatcher
+	}
+
+	return waitEvents(wc, evs), nil
+}
+
+func waitEvents(wc v3.WatchChan, evs []mvccpb.Event_EventType) *v3.Event {
+	i := 0
+
+	for wresp := range wc {
+		for _, ev := range wresp.Events {
+			if ev.Type == evs[i] {
+				i++
+				if i == len(evs) {
+					return ev
+				}
+			}
+		}
+	}
+
+	return nil
+}


### PR DESCRIPTION
A new method, IsHeld, has been added to the Mutex interface and its implementation to check if the mutex lock is held or not. The main feature addition is a distributed queue implementation using etcd which is included in queue.go. The additional queue struct methods support functionality such as producing and consuming messages from the queue, as well as committing a message. The newQueue function was added to help with the initialization of a new distributed queue. This will be beneficial in applications necessitating distributed systems with queue-like behavior.