### PR TITLE
feat: Updated mutex handling and fixed error messages

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -9,6 +9,10 @@ IMAGE_NAME 			= pudding/${APP}:latest
 SWAGGER_UI_VERSION	:=v4.15.5
 
 
+submodule:
+	git submodule update --init --recursive
+
+
 # clean
 clean:
 	@echo "clean build dir"
@@ -52,7 +56,7 @@ install/tools:
 	@go generate -x -tags tools tools/tools.go
 
 # bootstrap the build by downloading additional tools that may be used by devs
-bootstrap: install/tools gen/proto gen/struct_tag gen/mock
+bootstrap: submodule install/tools gen/proto gen/struct_tag gen/mock
 
 
 .PHONY: build/binary build/docker gen/proto gen/struct_tag gen/mock gen/swagger-ui install/tools bootstrap

--- a/pkg/cluster/cluster.go
+++ b/pkg/cluster/cluster.go
@@ -79,7 +79,7 @@ func (c *cluster) getSession(ctx context.Context, ttl int64) (*concurrency.Sessi
 		return nil, err
 	}
 
-	session, err := concurrency.NewSession(c.client, concurrency.WithLease(leaseID), concurrency.WithContext(ctx))
+	session, err := concurrency.NewSession(c.client, concurrency.WithLease(leaseID))
 	if err != nil {
 		return nil, fmt.Errorf("create session failed: %v", err)
 	}

--- a/pkg/cluster/mutex_test.go
+++ b/pkg/cluster/mutex_test.go
@@ -56,20 +56,17 @@ func refreshMutexAfter(t *testing.T, m Mutex, d time.Duration) {
 	}
 }
 
-func Test_mutex_TryLock(t *testing.T) {
-	mutex, err := testCluster.Mutex("test", 2*time.Second, WithDisableKeepalive())
+func Test_mutex_IsLocked(t *testing.T) {
+	mutex, err := testCluster.Mutex("test", 2*time.Second)
 	assert.NoError(t, err)
-	mutex2, err := testCluster.Mutex("test", 2*time.Second, WithDisableKeepalive())
+	mutex2, err := testCluster.Mutex("test", 2*time.Second)
 	assert.NoError(t, err)
 
 	ctx := context.Background()
 	assert.NoError(t, mutex.Lock(ctx))
-	held, err := mutex.TryLock()
-	assert.Equal(t, true, held)
-	held2, err := mutex2.TryLock()
-	assert.Equal(t, false, held2)
+	assert.Equal(t, true, mutex.IsLocked())
+	assert.Equal(t, false, mutex2.IsLocked())
 
 	assert.NoError(t, mutex.Unlock(ctx))
-	held, err = mutex.TryLock()
-	assert.Equal(t, true, held)
+	assert.Equal(t, false, mutex.IsLocked())
 }

--- a/pkg/cluster/queue.go
+++ b/pkg/cluster/queue.go
@@ -40,6 +40,7 @@ type Message struct {
 // /namespace/topic/unacked (value: consumer_id, rev)
 // /namespace/topic/consumer (mutex)
 type queue struct {
+	cluster       *cluster
 	client        *v3.Client
 	topic         string
 	consumerMutex Mutex
@@ -53,19 +54,27 @@ func (c *cluster) Queue(topic string) (Queue, error) {
 
 func newQueue(cluster *cluster, topic string) (*queue, error) {
 	q := queue{
+		cluster:    cluster,
 		client:     cluster.client,
 		topic:      topic,
 		consumerID: uuid.New().String(),
 	}
 
-	m, err := cluster.Mutex(q.getConsumerLockPath(), 10*time.Second)
-	if err != nil {
+	if err := q.newMutex(); err != nil {
 		return nil, err
 	}
 
-	q.consumerMutex = m
-
 	return &q, nil
+}
+
+func (q *queue) newMutex() error {
+	m, err := q.cluster.Mutex(q.getConsumerLockPath(), 10*time.Second)
+	if err != nil {
+		return err
+	}
+
+	q.consumerMutex = m
+	return nil
 }
 
 func (q *queue) Produce(m *Message) (string, error) {
@@ -91,9 +100,7 @@ func (q *queue) Consume(ctx context.Context) (*Message, error) {
 	for {
 		log.Debugf("try to get message from the topic [%s]", q.topic)
 
-		if held, err := q.consumerMutex.TryLock(); err != nil {
-			return nil, err
-		} else if !held {
+		if !q.consumerMutex.IsLocked() {
 			// wait for the lock, only one consumer can consume the message
 			if err := q.consumerMutex.Lock(ctx); err != nil {
 				return nil, err


### PR DESCRIPTION
Updated the handling of mutex locking, specifically changing the TryLock() implementation for a clearer IsLocked() method that doesn't throw errors.